### PR TITLE
Rl output cleanup

### DIFF
--- a/energiminer/CpuMiner.cpp
+++ b/energiminer/CpuMiner.cpp
@@ -12,7 +12,7 @@
 using namespace energi;
 
 CpuMiner::CpuMiner(const Plant &plant, int index)
-    :Miner("cpu", plant, index)
+    :Miner("CPU/", plant, index)
 {
 }
 

--- a/energiminer/MinerAux.cpp
+++ b/energiminer/MinerAux.cpp
@@ -336,7 +336,7 @@ void MinerCLI::doMiner()
                 mp.rate();
                 cnote << "Mining on difficulty " << " " << mp;
 
-                this_thread::sleep_for(chrono::milliseconds(500));
+                this_thread::sleep_for(chrono::milliseconds(6000));
             }
             // 7. Since solution was found, before submit stop all miners
             plant.stopAllWork();

--- a/energiminer/common.h
+++ b/energiminer/common.h
@@ -172,7 +172,7 @@ namespace energi
     uint64_t ms = 0;        ///< Total number of milliseconds of mining thus far.
     uint64_t rate() const { return ms == 0 ? 0 : hashes * 1000 / ms; }
 
-    std::vector<uint64_t> minersHashes;
+    std::map<std::string, uint64_t> minersHashes; // maps a miner's device name to it's hash count
     uint64_t minerRate(const uint64_t hashCount) const { return ms == 0 ? 0 : hashCount * 1000 / ms; }
   };
 
@@ -183,10 +183,10 @@ namespace energi
        << EthTealBold << std::fixed << std::setw(6) << std::setprecision(2) << mh << EthReset
        << " Kh/s    ";
 
-    for (size_t i = 0; i < _p.minersHashes.size(); ++i)
+    for (auto const & i : _p.minersHashes)
     {
-      mh = _p.minerRate(_p.minersHashes[i]) / 1000.0f;
-      _out << "device/" << i << " " << EthTeal << std::fixed << std::setw(5) << std::setprecision(2) << mh << EthReset << "  ";
+      mh = _p.minerRate(i.second) / 1000.0f;
+      _out << i.first << " " << EthTeal << std::fixed << std::setw(5) << std::setprecision(2) << mh << EthReset << "  ";
     }
 
     return _out;

--- a/energiminer/mineplant.cpp
+++ b/energiminer/mineplant.cpp
@@ -162,7 +162,7 @@ namespace energi
     {
       auto minerHashCount = miner->hashCount();
       p.hashes += minerHashCount;
-      p.minersHashes.push_back(minerHashCount);
+      p.minersHashes.insert(std::make_pair<std::string, uint64_t>(miner->name(), minerHashCount));
     }
 
     //Reset miner hashes
@@ -203,17 +203,16 @@ namespace energi
       MutexLGuard l(mutex_work_);
       for (auto const& miner : miners_)
       {
-        (void) miner;
-        p.minersHashes.push_back(0);
+        p.minersHashes.insert(std::make_pair<std::string, uint64_t>(miner->name(), 0));
       }
 
       for (auto const& cp : lastProgresses_)
       {
         p.ms += cp.ms;
         p.hashes += cp.hashes;
-        for (unsigned int i = 0; i < cp.minersHashes.size(); i++)
+        for (auto const & i : cp.minersHashes)
         {
-          p.minersHashes.at(i) += cp.minersHashes.at(i);
+          p.minersHashes.at(i.first) += i.second;
         }
       }
     }

--- a/energiminer/solution.cpp
+++ b/energiminer/solution.cpp
@@ -24,7 +24,7 @@ std::string Solution::getSubmitBlockData() const
         be32enc(const_cast<uint32_t*>(&v), v);
     }
 
-    bin2hex(const_cast<char*>(blockHeaderStr.c_str()), (unsigned char *)m_work.blockHeader.data(), 116);
+    bin2hex(const_cast<char*>(&blockHeaderStr[0]), (unsigned char *)m_work.blockHeader.data(), 116);
     std::stringstream ss;
     ss << blockHeaderStr.c_str() << m_work.rawTransactionData;
 

--- a/libegihash-cl/OpenCLMiner.cpp
+++ b/libegihash-cl/OpenCLMiner.cpp
@@ -558,6 +558,16 @@ bool OpenCLMiner::init_dag()
         addDefinition(code, "COMPUTE", std::get<3>(deviceResult));
         addDefinition(code, "THREADS_PER_HASH", s_threadsPerHash);
 
+        cnote << "DAG GROUP_SIZE=" << workgroupSize_;
+        cnote << "DAG_SIZE=" << dagSize;
+        cnote << "DAG_SIZE(128)=" << dagSize128;
+        cnote << "LIGHT_SIZE=" << lightSize64;
+        cnote << "ACCESSES=" << egihash::constants::ACCESSES;
+        cnote << "MAX_OUTPUTS=" << c_maxSearchResults;
+        cnote << "PLATTFORM=" << std::get<2>(deviceResult);
+        cnote << "COMPUTE=" << std::get<3>(deviceResult);
+        cnote << "THREADS_PER_HASH=" << s_threadsPerHash;
+
         // create miner OpenCL program
         cl::Program::Sources sources{{code.data(), code.size()}};
         cl::Program program(cl->context_, sources);

--- a/libegihash-cl/OpenCLMiner.cpp
+++ b/libegihash-cl/OpenCLMiner.cpp
@@ -593,7 +593,7 @@ bool OpenCLMiner::init_dag()
             cl->kernelSearch_     = cl::Kernel(program, "ethash_search");
             cl->kernelDag_        = cl::Kernel(program, "ethash_calculate_dag_item");
 
-            ETHCL_LOG("Caeating light buffer");
+            ETHCL_LOG("Creating light buffer");
 
             cl->queue_.enqueueWriteBuffer(cl->bufferLight_, CL_TRUE, 0, sizeof(uint32_t) * vData.size(), vData.data());
         } catch (cl::Error const& err) {

--- a/libegihash-cl/OpenCLMiner.cpp
+++ b/libegihash-cl/OpenCLMiner.cpp
@@ -252,7 +252,7 @@ struct OpenCLMiner::clInfo
 };
 
 OpenCLMiner::OpenCLMiner(const Plant& plant, unsigned index)
-    : Miner("cl", plant, index)
+    : Miner("GPU/", plant, index)
     , cl(new clInfo)
 {
 }


### PR DESCRIPTION
* fixes small string optimization bug (cannot write to ptr returned by `c_str()`)
* improves output so that we can see which devices are doing which operations
* reduces hashrate output frequency