### PR TITLE
Rl gpuminer fixes 3

### DIFF
--- a/energiminer/CpuMiner.cpp
+++ b/energiminer/CpuMiner.cpp
@@ -24,7 +24,7 @@ void CpuMiner::trun()
     try {
         unsigned int nExtraNonce = 0;
         while (true) {
-            Work work = this->work(); // This work is a copy of last assigned work the worker was provided by plant
+            Work work = this->getWork(); // This work is a copy of last assigned work the worker was provided by plant
             if ( !work.isValid() ) {
                 cnote << "No work received. Pause for 1 s.";
                 std::this_thread::sleep_for(std::chrono::seconds(1));

--- a/energiminer/MinerAux.cpp
+++ b/energiminer/MinerAux.cpp
@@ -65,17 +65,17 @@ bool MinerCLI::interpretOption(int& i, int argc, char** argv)
                 break;
             }
         }
-    } else if(arg == "--cl-parallel-hash" && i + 1 < argc) {
-        try {
-            m_openclThreadsPerHash = stol(argv[++i]);
-            if(m_openclThreadsPerHash != 1 && m_openclThreadsPerHash != 2 &&
-                    m_openclThreadsPerHash != 4 && m_openclThreadsPerHash != 8) {
-                throw;
-            }
-        } catch(...) {
-            cerr << "Bad " << arg << " option: " << argv[i] << endl;
-            throw;
-        }
+    //} else if(arg == "--cl-parallel-hash" && i + 1 < argc) {
+    //    try {
+    //        m_openclThreadsPerHash = stol(argv[++i]);
+    //        if(m_openclThreadsPerHash != 1 && m_openclThreadsPerHash != 2 &&
+    //                m_openclThreadsPerHash != 4 && m_openclThreadsPerHash != 8) {
+    //            throw;
+    //        }
+    //    } catch(...) {
+    //        cerr << "Bad " << arg << " option: " << argv[i] << endl;
+    //        throw;
+    //    }
     } else if ((arg == "--cl-global-work" || arg == "--cuda-grid-size")  && i + 1 < argc) {
         try {
             m_globalWorkSizeMultiplier = stol(argv[++i]);

--- a/energiminer/MinerAux.cpp
+++ b/energiminer/MinerAux.cpp
@@ -150,13 +150,13 @@ bool MinerCLI::interpretOption(int& i, int argc, char** argv)
                 }
             }
         }
-    } else if ((arg == "-t" || arg == "--mining-threads") && i + 1 < argc) {
-        try {
-            m_miningThreads = stol(argv[++i]);
-        } catch (...) {
-            cerr << "Bad " << arg << " option: " << argv[i] << endl;
-            throw;
-        }
+    //} else if ((arg == "-t" || arg == "--mining-threads") && i + 1 < argc) {
+    //    try {
+    //        m_miningThreads = stol(argv[++i]);
+    //    } catch (...) {
+    //        cerr << "Bad " << arg << " option: " << argv[i] << endl;
+    //        throw;
+    //    }
     } else {
         return false;
     }

--- a/energiminer/MinerAux.cpp
+++ b/energiminer/MinerAux.cpp
@@ -318,6 +318,7 @@ void MinerCLI::doMiner()
         try {
             solution_found = false;
             // Keep checking for new work and mine
+            unsigned int i = 0;
             while(!solution_found) {
                 energi::Work new_work = client->getWork();
                 // check if current work is no different, then skip
@@ -334,8 +335,14 @@ void MinerCLI::doMiner()
                 }
                 auto mp = plant.miningProgress();
                 mp.rate();
+                // should output about once a minute
+                if ((++i % 1200) == 0)
+                {
+                    i = 0;
+                    cnote << mp;
+                }
 
-                this_thread::sleep_for(chrono::milliseconds(500));
+                this_thread::sleep_for(chrono::milliseconds(50));
             }
             // 7. Since solution was found, before submit stop all miners
             plant.stopAllWork();

--- a/energiminer/MinerAux.cpp
+++ b/energiminer/MinerAux.cpp
@@ -335,8 +335,8 @@ void MinerCLI::doMiner()
                 }
                 auto mp = plant.miningProgress();
                 mp.rate();
-                // should output about once a minute
-                if ((++i % 1200) == 0)
+                // should output about once every 30 seconds
+                if (((++i % 600) == 0) && (mp.hashes > 0))
                 {
                     i = 0;
                     cnote << mp;

--- a/energiminer/MinerAux.h
+++ b/energiminer/MinerAux.h
@@ -105,7 +105,7 @@ public:
 			<< "    --list-devices List the detected OpenCL/CUDA devices and exit." << endl
 			<< "    --cl-local-work Set the OpenCL local work size. Default is " << OpenCLMiner::c_defaultLocalWorkSize << endl
 			<< "    --cl-global-work Set the OpenCL global work size as a multiple of the local work size. Default is " << OpenCLMiner::c_defaultGlobalWorkSizeMultiplier << " * " << OpenCLMiner::c_defaultLocalWorkSize << endl
-			<< "    --cl-parallel-hash <1 2 ..8> Define how many threads to associate per hash. Default=8" << endl
+			//<< "    --cl-parallel-hash <1 2 ..8> Define how many threads to associate per hash. Default=8" << endl
 			;
 	}
 

--- a/energiminer/MinerAux.h
+++ b/energiminer/MinerAux.h
@@ -98,11 +98,11 @@ public:
 			<< "Simulation mode:" << endl
 			<< "    -Z [<n>],--simulation [<n>] Mining test mode. Used to validate kernel optimizations. Optionally specify block number." << endl
 			<< "Mining configuration:" << endl
-			<< "    --opencl-platform <n>  When mining using -G/--opencl use OpenCL platform n (default: 0)." << endl
-			<< "    --opencl-device <n>  When mining using -G/--opencl use OpenCL device n (default: 0)." << endl
+			<< "    --opencl-platform <n>  When mining use OpenCL platform n (default: 0)." << endl
+			<< "    --opencl-device <n>  When mining use OpenCL device n (default: 0)." << endl
 			<< "    --opencl-devices <0 1 ..n> Select which OpenCL devices to mine on. Default is to use all" << endl
-			<< "    -t, --mining-threads <n> Limit number of CPU/GPU miners to n (default: use everything available on selected platform)" << endl
-			<< "    --list-devices List the detected OpenCL/CUDA devices and exit. Should be combined with -G or -U flag" << endl
+			//<< "    -t, --mining-threads <n> Limit number of CPU/GPU miners to n (default: use everything available on selected platform)" << endl
+			<< "    --list-devices List the detected OpenCL/CUDA devices and exit." << endl
 			<< "    --cl-local-work Set the OpenCL local work size. Default is " << OpenCLMiner::c_defaultLocalWorkSize << endl
 			<< "    --cl-global-work Set the OpenCL global work size as a multiple of the local work size. Default is " << OpenCLMiner::c_defaultGlobalWorkSizeMultiplier << " * " << OpenCLMiner::c_defaultLocalWorkSize << endl
 			<< "    --cl-parallel-hash <1 2 ..8> Define how many threads to associate per hash. Default=8" << endl
@@ -146,10 +146,10 @@ private:
 
 	/// Mining options
 	bool should_mine = true;
-	MinerExecutionMode m_minerExecutionMode = MinerExecutionMode::kCPU;
+	MinerExecutionMode m_minerExecutionMode = MinerExecutionMode::kCL;
 
 	unsigned m_openclPlatform = 0;
-	unsigned m_miningThreads = UINT_MAX;
+	unsigned m_miningThreads = 1;
 	bool m_shouldListDevices = false;
 
 	unsigned m_openclDeviceCount = 0;

--- a/energiminer/primitives/block.h
+++ b/energiminer/primitives/block.h
@@ -33,7 +33,7 @@ struct BlockHeader
     BlockHeader(const Json::Value& gbt)
     {
         nVersion         = gbt["version"].asInt();
-        hashPrevBlock.SetHex(gbt["previousblockhash"].asString());
+        hashPrevBlock = uint256S(gbt["previousblockhash"].asString());
         hashMerkleRoot.SetNull();
         nTime            = gbt["curtime"].asInt();
         std::string bits = gbt["bits"].asString();

--- a/energiminer/primitives/uint256.h
+++ b/energiminer/primitives/uint256.h
@@ -165,7 +165,11 @@ public:
     explicit uint256(const egihash::h256_t & h)
         : base_blob<256>()
     {
-        memcpy(data, h.b, h.hash_size);
+        // copy to internal byte order for this type
+        for (size_t i = 0; i < 32; i++)
+        {
+            data[31-i] = h.b[i];
+        }
     }
 
     /**

--- a/energiminer/work.cpp
+++ b/energiminer/work.cpp
@@ -36,4 +36,10 @@ void Work::incrementExtraNonce(unsigned int& nExtraNonce)
    this->hashMerkleRoot = BlockMerkleRoot(*this);
 }
 
+void Work::incrementExtraNonce()
+{
+    unsigned int extraNonce=0;
+    incrementExtraNonce(extraNonce);
+}
+
 } //! namespace energi

--- a/energiminer/work.h
+++ b/energiminer/work.h
@@ -63,6 +63,7 @@ struct Work : public Block
         return m_jobName;
     }
 
+    void incrementExtraNonce();
     void incrementExtraNonce(unsigned int& nExtraNonce);
 
     ADD_SERIALIZE_METHODS

--- a/energiminer/worker.cpp
+++ b/energiminer/worker.cpp
@@ -73,6 +73,7 @@ void Worker::setWork(const Work& work)
 {
     std::lock_guard<std::recursive_mutex> lock(m_mutex);
     m_work = work;
+    m_work.incrementExtraNonce();
     m_state = State::Starting;
 
     onSetWork();

--- a/energiminer/worker.h
+++ b/energiminer/worker.h
@@ -53,7 +53,7 @@ public:
     // work in a thread, protect the data carefully.
     void setWork(const Work& work);
 
-    Work work()
+    Work getWork()
     {
         std::lock_guard<std::recursive_mutex> lock(m_mutex);
         return m_work;

--- a/libegihash-cl/OpenCLMiner.cpp
+++ b/libegihash-cl/OpenCLMiner.cpp
@@ -15,11 +15,6 @@
 #include <vector>
 #include <iostream>
 
-// uncomment the following for being able to print in a useful way
-//#define DEBUG_SINGLE_THREADED_OPENCL
-// uncomment the following to skip DAG generation for faster debugging
-//#define DEBUG_SKIP_DAG_GENERATION
-
 namespace {
 
 const char* strClError(cl_int err)
@@ -639,15 +634,14 @@ bool OpenCLMiner::init_dag(uint32_t height)
         cl->kernelDag_.setArg(2, cl->bufferDag_);
         cl->kernelDag_.setArg(3, ~0u);
 
-        #ifndef DEBUG_SKIP_DAG_GENERATION
         for (uint32_t i = 0; i < fullRuns; ++i) {
             cl->kernelDag_.setArg(0, i * globalWorkSize_);
             cl->queue_.enqueueNDRangeKernel(cl->kernelDag_, cl::NullRange, globalWorkSize_, workgroupSize_);
             cl->queue_.finish();
         }
-        #endif
 
         cllog << "DAG Loaded" ;
+
     } catch (cl::Error const& err) {
         cwarn << err.what() << "(" << err.err() << ")";
         return false;

--- a/libegihash-cl/OpenCLMiner.cpp
+++ b/libegihash-cl/OpenCLMiner.cpp
@@ -15,11 +15,6 @@
 #include <vector>
 #include <iostream>
 
-// uncomment the following for being able to print in a useful way
-//#define DEBUG_SINGLE_THREADED_OPENCL
-// uncomment the following to skip DAG generation for faster debugging
-//#define DEBUG_SKIP_DAG_GENERATION
-
 namespace {
 
 const char* strClError(cl_int err)
@@ -430,12 +425,8 @@ void OpenCLMiner::trun()
             }
             // Run the kernel.
             cl->kernelSearch_.setArg(3, startNonce);
-
-            #ifdef DEBUG_SINGLE_THREADED_OPENCL
-            cl->queue_.enqueueTask(cl->kernelSearch_);
-            #else
             cl->queue_.enqueueNDRangeKernel(cl->kernelSearch_, cl::NullRange, globalWorkSize_, workgroupSize_);
-            #endif
+
             // Report results while the kernel is running.
             // It takes some time because proof of work must be re-evaluated on CPU.
             if (nonce != 0) {
@@ -646,13 +637,11 @@ bool OpenCLMiner::init_dag(uint32_t height)
         cl->kernelDag_.setArg(2, cl->bufferDag_);
         cl->kernelDag_.setArg(3, ~0u);
 
-        #ifndef DEBUG_SKIP_DAG_GENERATION
         for (uint32_t i = 0; i < fullRuns; ++i) {
             cl->kernelDag_.setArg(0, i * globalWorkSize_);
             cl->queue_.enqueueNDRangeKernel(cl->kernelDag_, cl::NullRange, globalWorkSize_, workgroupSize_);
             cl->queue_.finish();
         }
-        #endif
 
         cllog << "DAG Loaded" ;
 

--- a/libegihash-cl/OpenCLMiner.cpp
+++ b/libegihash-cl/OpenCLMiner.cpp
@@ -399,12 +399,12 @@ void OpenCLMiner::trun()
                 cl->kernelSearch_.setArg(4, target);
 
                 startNonce  = m_nonceStart.load();
-                cllog << "Nonce loaded" << startNonce;
+                //cllog << "Nonce loaded" << startNonce;
 
                 auto switchEnd = std::chrono::high_resolution_clock::now();
                 auto globalSwitchTime = std::chrono::duration_cast<std::chrono::milliseconds>(switchEnd - workSwitchStart).count();
                 auto localSwitchTime = std::chrono::duration_cast<std::chrono::microseconds>(switchEnd - localSwitchStart).count();
-                cllog << "Switch time" << globalSwitchTime << "ms /" << localSwitchTime << "us";
+                //cllog << "Switch time" << globalSwitchTime << "ms /" << localSwitchTime << "us";
             }
 
             // Run the kernel.

--- a/libegihash-cl/OpenCLMiner.cpp
+++ b/libegihash-cl/OpenCLMiner.cpp
@@ -392,17 +392,13 @@ void OpenCLMiner::trun()
                 energi::CBlockHeaderTruncatedLE truncatedBlockHeader(work);
                 egihash::h256_t hash_header(&truncatedBlockHeader, sizeof(truncatedBlockHeader));
 
-                std::vector<uint8_t> h2;
-                h2.reserve(32);
-                std::reverse_copy(&hash_header.b[0], &hash_header.b[32], h2.begin());
-
                 // Upper 64 bits of the boundary.
                 const uint64_t target = *reinterpret_cast<uint64_t const *>((work.hashTarget >> 192).data());
                 assert(target > 0);
 
                 // Update header constant buffer.
-                cl->queue_.enqueueWriteBuffer(cl->bufferHeader_, CL_FALSE, 0, 32, h2.data());
-                cl->queue_.enqueueWriteBuffer(cl->searchBuffer_, CL_FALSE, 0, sizeof(c_zero), &c_zero);
+                cl->queue_.enqueueWriteBuffer(cl->bufferHeader_, CL_TRUE, 0, hash_header.hash_size, &hash_header.b[0]);
+                cl->queue_.enqueueWriteBuffer(cl->searchBuffer_, CL_TRUE, 0, sizeof(c_zero), &c_zero);
 
                 cl->kernelSearch_.setArg(0, cl->searchBuffer_);  // Supply output buffer to kernel.
                 cl->kernelSearch_.setArg(4, target);

--- a/libegihash-cl/OpenCLMiner.cpp
+++ b/libegihash-cl/OpenCLMiner.cpp
@@ -377,7 +377,6 @@ void OpenCLMiner::trun()
             work.incrementExtraNonce(nExtraNonce);
             if ( current_work != work ) {
                 cllog << "Bits:" << " " << work.nBits;
-                auto localSwitchStart = std::chrono::high_resolution_clock::now();
 
                 if (!dagLoaded_ || (egihash::cache_t::get_seedhash(current_work.nHeight) != egihash::cache_t::get_seedhash(work.nHeight))) {
                     init_dag(work.nHeight);
@@ -400,11 +399,6 @@ void OpenCLMiner::trun()
 
                 startNonce  = m_nonceStart.load();
                 //cllog << "Nonce loaded" << startNonce;
-
-                auto switchEnd = std::chrono::high_resolution_clock::now();
-                auto globalSwitchTime = std::chrono::duration_cast<std::chrono::milliseconds>(switchEnd - workSwitchStart).count();
-                auto localSwitchTime = std::chrono::duration_cast<std::chrono::microseconds>(switchEnd - localSwitchStart).count();
-                //cllog << "Switch time" << globalSwitchTime << "ms /" << localSwitchTime << "us";
             }
 
             // Run the kernel.

--- a/libegihash-cl/OpenCLMiner.cpp
+++ b/libegihash-cl/OpenCLMiner.cpp
@@ -353,7 +353,7 @@ bool OpenCLMiner::configureGPU(
         cwarn << "OpenCL device " << device.getInfo<CL_DEVICE_NAME>() << " has insufficient GPU memory." << result <<
             " bytes of memory found < " << dagSize << " bytes of memory required";
     }
-    cllog << "No GPU device with sufficient memory was found. Can't GPU mine. Remove the -G argument" ;
+    cllog << "No GPU device with sufficient memory was found, unable to mine Energi." ;
     return false;
 }
 

--- a/libegihash-cl/OpenCLMiner.cpp
+++ b/libegihash-cl/OpenCLMiner.cpp
@@ -655,8 +655,6 @@ bool OpenCLMiner::init_dag(uint32_t height)
         #endif
 
         cllog << "DAG Loaded" ;
-
-        std::this_thread::sleep_for(std::chrono::seconds(10));
     } catch (cl::Error const& err) {
         cwarn << err.what() << "(" << err.err() << ")";
         return false;

--- a/libegihash-cl/OpenCLMiner.cpp
+++ b/libegihash-cl/OpenCLMiner.cpp
@@ -360,7 +360,6 @@ void OpenCLMiner::trun()
     uint64_t startNonce = 0;
     Work current_work; // Here we need current work as to initialize gpu
     try {
-        unsigned int nExtraNonce = 0;
         while (!shouldStop()) {
             Work work = this->getWork(); // This work is a copy of last assigned work the worker was provided by plant
             if ( !work.isValid() ) {
@@ -374,7 +373,6 @@ void OpenCLMiner::trun()
                 //cnote << "Valid work.";
             }
 
-            work.incrementExtraNonce(nExtraNonce);
             if ( current_work != work ) {
                 cllog << "Bits:" << " " << work.nBits;
 

--- a/libegihash-cl/OpenCLMiner.cpp
+++ b/libegihash-cl/OpenCLMiner.cpp
@@ -367,7 +367,7 @@ void OpenCLMiner::trun()
     try {
         unsigned int nExtraNonce = 0;
         while (!shouldStop()) {
-            Work work = this->work(); // This work is a copy of last assigned work the worker was provided by plant
+            Work work = this->getWork(); // This work is a copy of last assigned work the worker was provided by plant
             if ( !work.isValid() ) {
                 cdebug << "No work received. Pause for 1 s.";
                 std::this_thread::sleep_for(std::chrono::seconds(1));


### PR DESCRIPTION
* fixes numerous problems in OpenCL mining code
* fixes synchronization issues when reading the OpenCL miner result
* fixes synchronization issue clearing the result bit
* fixes synchronization issue writing the block header
* fixes `extraNonce` synchronization issue
* POWHash internal byte order fix (See https://github.com/energicryptocurrency/energi/pull/258)
* disabled some irrelevant command line options like `--cl-parallel-hash`
* re-enabled and improved mining speed output
* fixed overlapping threads trying to GPU mine with the same GPU
* disabled CPU miner